### PR TITLE
hotfix EC2 인스턴스 변경

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,8 +76,7 @@ jobs:
           host: ${{ env.EC2_BASTION_HOST }}
           debug: true
           username: ubuntu
-          key: ${{ secrets.SSH_SECRET_ACCESS_KEY }}
           port: 22
           envs: EC2_BACKEND_HOST,GITHUB_SHA,ECR_REGISTRY
           script: |
-            ssh -i ~/.ssh/swm-nm-morandi.pem -o StrictHostKeyChecking=no ubuntu@$EC2_BACKEND_HOST 'bash /home/ubuntu/morandi-backend/deploy.sh'
+            ssh -o StrictHostKeyChecking=no ubuntu@$EC2_BACKEND_HOST 'bash /home/ubuntu/morandi-backend/deploy.sh'


### PR DESCRIPTION
# PR 제목
hotfix EC2 인스턴스 변경

## 변경 사항 요약
AWS 계정 이동으로 CI/CD 설정을 변경합니다.
bastion host의 공개 키는 Backend 인스턴스에 넣어두어 더이상 key를 필요로 하지 않으므로 삭제합니다.